### PR TITLE
fix: Remove whitespace between social icons in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,7 @@
   
 <a href="mailto:cobekgn@gmail.com">
     <img src="https://img.shields.io/badge/Gmail-333333?style=for-the-badge&logo=gmail&logoColor=red" />
-  </a>
-  <a href="" target="_blank">
+  </a><a href="" target="_blank">
      <img src="https://img.shields.io/badge/Portfolio-FF5722?style=for-the-badge&logo=todoist&logoColor=white" target="_blank" /> <!-- sqlite, safari, google-chrome are other good icon options -->
   </a>
 


### PR DESCRIPTION
Removed the whitespace between the Gmail and Portfolio `<a>` tags to prevent a potential rendering artifact that appeared as an underscore.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the formatting of the social badges section in the README for improved HTML structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->